### PR TITLE
Lower minimum PHP requirement from 8.4 to 8.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ GitHub: [Jesusjeco](https://github.com/Jesusjeco)
 ## Requirements
 
 - WordPress 6.0+
-- PHP 8.4+
+- PHP 8.2+
 
 ---
 

--- a/jeco-ip-blacklist.php
+++ b/jeco-ip-blacklist.php
@@ -5,7 +5,7 @@ Description: Automatically updates .htaccess with the latest IP blacklist to blo
 Version: 2.0.0
 Author: Jesus Carrero
 Requires at least: 6.0
-Requires PHP: 8.4
+Requires PHP: 8.2
 */
 
 // Exit if accessed directly


### PR DESCRIPTION
Plugin code uses no PHP 8.3+ or 8.4+ features — the 8.4 declaration was incorrect and prevented activation on PHP 8.2 hosts.